### PR TITLE
Ignore .git/lfs when checking for LFS in a repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changelog for v0.1.0
+
+- Removed the `repoHasLfsBin` helper
+
 # Changelog for v0.0.19
 
 - Update `node-pty` to fix the high sierra issue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodegit-lfs",
-  "version": "0.0.19",
+  "version": "0.1.0",
   "description": "A wrapper for NodeGit to facilitate LFS Support",
   "main": "build/src/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,11 +43,7 @@ export const repoHasLfsFilters = repo => loadGitattributeFiltersFromRepo(repo)
   .then(filters => filters.length > 0)
   .catch(() => false);
 
-export const repoHasLfsObjectBin = repo =>
-  fse.pathExists(path.join(repo.workdir(), '.git', 'lfs'));
-
-export const repoHasLfs = repo => repoHasLfsFilters(repo)
-    .then(hasFilters => hasFilters || repoHasLfsObjectBin(repo));
+export const repoHasLfs = repoHasLfsFilters;
 
 export const regexResult = (input, regularExpression) => input.match(regularExpression);
 


### PR DESCRIPTION
Git core runs LFS operations based on the filters in `.gitattributes` and doesn't care about `.git/lfs`, so neither should we.