### PR TITLE
Increase child_process exec's `maxBuffer` when executing `git lfs ls-files`

### DIFF
--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -52,7 +52,10 @@ const ls = (repo, options) => {
   const args = buildArgs(options);
   const { shellOptions } = (options || {});
 
-  return core.ls(args, R.mergeDeepRight(shellOptions, { cwd: repoPath }))
+  return core.ls(
+    args,
+    R.mergeDeepRight(shellOptions, { cwd: repoPath, maxBuffer: 4194304 })
+  )
     .then(({ stdout, stderr }) => {
       response.raw = stdout;
 


### PR DESCRIPTION
`git lfs ls-files` can potentially return an extensive amount of data in stdout, greater than the default size of `maxBuffer` in nodejs's child_process exec, which is 1024*1024, even more if we consider [multibyte character encodings](https://nodejs.org/api/child_process.html#maxbuffer-and-unicode).
For repos with a big amount of LFS files –to prevent the child process from being terminated and its output truncated– we can increase `maxBuffer` 4 times its current default size when executing `git lfs ls-files`.